### PR TITLE
setup_dev_environment: fix formatting

### DIFF
--- a/content/dev_manual/setup_dev_environment.md
+++ b/content/dev_manual/setup_dev_environment.md
@@ -31,8 +31,9 @@ You will need PostgreSQL 9.4+ for the `jsonb` data type.
 
 ### Ubuntu 12.04, 14.04, 16.04
 
-```postgresql-9.6``` and ```postgresql-contrib-9.6``` is not in the repo, [ask ubuntu](https://askubuntu.com/questions/831292/how-do-i-install-postgresql-9-6-on-any-ubuntu-version) has the commands for adding the ppa and installing version 9.6.
-If you do not have wget installed, install it using ```sudo apt-get install wget```.
+`postgresql-9.6` and `postgresql-contrib-9.6` is not in the repo, [ask ubuntu](https://askubuntu.com/questions/831292/how-do-i-install-postgresql-9-6-on-any-ubuntu-version) has the commands for adding the ppa and installing version 9.6.
+
+If you do not have wget installed, install it using `sudo apt-get install wget`.
 
 ### All Ubuntu
 


### PR DESCRIPTION
This should fix loomio/loomio#4930 — currently, the [dev env setup page](https://help.loomio.org/en/dev_manual/setup_dev_environment/) has code and prose inverted for a large portion of the document.